### PR TITLE
Update README to reflect deleteIdleStats behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Metrics aggregation daemon like [statsd](https://github.com/etsy/statsd), in Go 
 Features you expect:
 =======================
 
-For a given input, this implementation yields the exact same metrics as etsy's statsd (with legacy namespace and deleteGauges enabled),
+For a given input, this implementation yields the exact same metrics as etsy's statsd (with legacy namespace and deleteIdleStats enabled),
 so it can act as a drop-in replacement.  In terms of types:
 
 * Timing (with optional percentiles, sampling supported)


### PR DESCRIPTION
Previously the docs indicated that "[statsdaemon] yields the exact same
metrics as etsy's statsd with legacy namespace and deleteGauges
enabled)". This implies that the behavior w.r.t. other delete* statsd
config options is in line with the defaults (deleteTimers=false and
deleteCounters=false). It seems though the behavior w.r.t. these types
of metrics is actually like deleteTimers=true and deleteCounters=true.
Given this, update the docs to reflect that overall behavior is really
comparable to the statsd configuration deleteIdleStats=true
(encompassing the various configs above).

One case where you can see this behavior difference is when either
timers or counters are sent input less frequently than the configured
flush intervals. In these cases, statsdaemon will not send any metrics
info to Graphite during the periods without input, while statsd in its
default configuration will send e.g. 0 valued metrics to Graphite for
counters.

Unfortunately this behavior difference prevented us from immediately
moving from statsd to stasdaemon. If you're interested, I'd consider
submitting a path that optionally preserved this aspect of statsd
behavior.
