### PR TITLE
Add prefix_internal variable so tests run

### DIFF
--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 var output = common.NullOutput()
+var prefix_internal = ""
 
 func TestPacketParse(t *testing.T) {
 	d := []byte("gaugor:333|g")


### PR DESCRIPTION
prefix_internal was factored away in 11faaf186a043964fae51260386dac427c3b7c50 so all tests were failing.  This adds a dummy variable so the tests pass again.