### PR TITLE
feat(counters): Adds `.count` metric for counters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ graphite_addr = "127.0.0.1:2003"
 flush_interval = 60
 
 prefix_rates = "stats."
-prefix_counters = "stats.counters"
+prefix_counters = "stats.counters."
 prefix_timers = "stats.timers."
 prefix_gauges = "stats.gauges."
 

--- a/README.md
+++ b/README.md
@@ -117,16 +117,21 @@ admin_addr = ":8126"
 graphite_addr = "127.0.0.1:2003"
 flush_interval = 60
 
+legacyNamespace = true
 prefix_rates = "stats."
-prefix_counters = "stats.counters."
+prefix_counters = "stats_counts."
 prefix_timers = "stats.timers."
 prefix_gauges = "stats.gauges."
 
-# send rates for counters (using prefix_rates)
-send_rates = true
+# Recommended (legacyNamespace = false)
+# counts -> stats.counters.$metric.count
+# rates -> stats.counters.$metric.rate
 
-# send count for counters (using prefix_counters)
-send_counters = false
+#legacyNamespace = false
+#prefix_rates = "stats.counters."
+#prefix_counters = "stats.counters."
+#prefix_timers = "stats.timers."
+#prefix_gauges = "stats.gauges."
 
 percentile_thresholds = "90,75"
 max_timers_per_s = 1000

--- a/README.md
+++ b/README.md
@@ -117,21 +117,26 @@ admin_addr = ":8126"
 graphite_addr = "127.0.0.1:2003"
 flush_interval = 60
 
-legacyNamespace = true
+legacy_namespace = true
 prefix_rates = "stats."
 prefix_counters = "stats_counts."
 prefix_timers = "stats.timers."
 prefix_gauges = "stats.gauges."
 
-# Recommended (legacyNamespace = false)
+# Recommended (legacy_namespace = false)
 # counts -> stats.counters.$metric.count
 # rates -> stats.counters.$metric.rate
 
-#legacyNamespace = false
+#legacy_namespace = false
 #prefix_rates = "stats.counters."
 #prefix_counters = "stats.counters."
 #prefix_timers = "stats.timers."
 #prefix_gauges = "stats.gauges."
+
+# send rates for counters (using prefix_rates)
+flush_rates = true
+# send count for counters (using prefix_counters)
+flush_counts = false
 
 percentile_thresholds = "90,75"
 max_timers_per_s = 1000

--- a/README.md
+++ b/README.md
@@ -118,8 +118,15 @@ graphite_addr = "127.0.0.1:2003"
 flush_interval = 60
 
 prefix_rates = "stats."
+prefix_counters = "stats.counters"
 prefix_timers = "stats.timers."
 prefix_gauges = "stats.gauges."
+
+# send rates for counters (using prefix_rates)
+send_rates = true
+
+# send count for counters (using prefix_counters)
+send_counters = false
 
 percentile_thresholds = "90,75"
 max_timers_per_s = 1000

--- a/counters/counters.go
+++ b/counters/counters.go
@@ -37,14 +37,14 @@ func (c *Counters) Process(buffer *bytes.Buffer, now int64, interval int) int64 
 	for key, val := range c.Values {
 		if c.sendCounters {
 			fmt.Fprintf(buffer, "%s %f %d\n", m20.Count(key, c.prefixCounters), val, now)
+			num++
 		}
 
 		if c.sendRates {
 			val := val / float64(interval)
 			fmt.Fprintf(buffer, "%s %f %d\n", m20.DeriveCount(key, c.prefixRates), val, now)
+			num++
 		}
-
-		num++
 	}
 	return num
 }

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -39,7 +39,9 @@ type StatsDaemon struct {
 	prefix_counters     string
 	prefix_timers       string
 	prefix_gauges       string
-	legacyNamespace     bool
+	legacy_namespace    bool
+	flush_rates         bool
+	flush_counts        bool
 	pct                 timers.Percentiles
 	flushInterval       int
 	max_unprocessed     int
@@ -56,7 +58,7 @@ type StatsDaemon struct {
 	submitFunc          SubmitFunc
 }
 
-func New(instance, prefix_rates, prefix_timers, prefix_gauges, prefix_counters string, pct timers.Percentiles, flushInterval, max_unprocessed int, max_timers_per_s uint64, signalchan chan os.Signal, debug bool, legacyNamespace bool) *StatsDaemon {
+func New(instance, prefix_rates, prefix_timers, prefix_gauges, prefix_counters string, pct timers.Percentiles, flushInterval, max_unprocessed int, max_timers_per_s uint64, signalchan chan os.Signal, debug bool, legacy_namespace bool, flush_rates bool, flush_counts bool) *StatsDaemon {
 	return &StatsDaemon{
 		instance,
 		"",
@@ -67,7 +69,9 @@ func New(instance, prefix_rates, prefix_timers, prefix_gauges, prefix_counters s
 		prefix_counters,
 		prefix_timers,
 		prefix_gauges,
-		legacyNamespace,
+		legacy_namespace,
+		flush_rates,
+		flush_counts,
 		pct,
 		flushInterval,
 		max_unprocessed,
@@ -137,7 +141,7 @@ func (s *StatsDaemon) metricsMonitor() {
 	}
 
 	initializeCounters := func() {
-		c = counters.New(s.prefix_rates, s.prefix_counters, s.legacyNamespace)
+		c = counters.New(s.prefix_rates, s.prefix_counters, s.legacy_namespace, s.flush_rates, s.flush_counts)
 		g = gauges.New(s.prefix_gauges)
 		t = timers.New(s.prefix_timers, s.pct)
 		for _, name := range []string{"timer", "gauge", "counter"} {

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -39,8 +39,7 @@ type StatsDaemon struct {
 	prefix_counters     string
 	prefix_timers       string
 	prefix_gauges       string
-	send_rates          bool
-	send_counters       bool
+	legacyNamespace     bool
 	pct                 timers.Percentiles
 	flushInterval       int
 	max_unprocessed     int
@@ -57,7 +56,7 @@ type StatsDaemon struct {
 	submitFunc          SubmitFunc
 }
 
-func New(instance, prefix_rates, prefix_timers, prefix_gauges, prefix_counters string, pct timers.Percentiles, flushInterval, max_unprocessed int, max_timers_per_s uint64, signalchan chan os.Signal, debug bool, send_rates bool, send_counters bool) *StatsDaemon {
+func New(instance, prefix_rates, prefix_timers, prefix_gauges, prefix_counters string, pct timers.Percentiles, flushInterval, max_unprocessed int, max_timers_per_s uint64, signalchan chan os.Signal, debug bool, legacyNamespace bool) *StatsDaemon {
 	return &StatsDaemon{
 		instance,
 		"",
@@ -68,8 +67,7 @@ func New(instance, prefix_rates, prefix_timers, prefix_gauges, prefix_counters s
 		prefix_counters,
 		prefix_timers,
 		prefix_gauges,
-		send_rates,
-		send_counters,
+		legacyNamespace,
 		pct,
 		flushInterval,
 		max_unprocessed,
@@ -139,7 +137,7 @@ func (s *StatsDaemon) metricsMonitor() {
 	}
 
 	initializeCounters := func() {
-		c = counters.New(s.send_rates, s.prefix_rates, s.send_counters, s.prefix_counters)
+		c = counters.New(s.prefix_rates, s.prefix_counters, s.legacyNamespace)
 		g = gauges.New(s.prefix_gauges)
 		t = timers.New(s.prefix_timers, s.pct)
 		for _, name := range []string{"timer", "gauge", "counter"} {

--- a/statsdaemon.ini
+++ b/statsdaemon.ini
@@ -13,16 +13,24 @@ processes = 4
 instance = "${HOST}"
 
 # prefixes for the various types.  they should probably end with a dot.
+# Defaults are in line with etsy statsd using legacy namespacing (not recommended)
+legacyNamespace = true
 prefix_rates = "stats."
-prefix_counters = "stats.counters."
+prefix_counters = "stats_counts."
 prefix_timers = "stats.timers."
 prefix_gauges = "stats.gauges."
 
-# send rates for counters (using prefix_rates)
-send_rates = true
+# Recommended (legacyNamespace = false)
+# counts -> stats.counters.$metric.count
+# rates -> stats.counters.$metric.rate
 
-# send count for counters (using prefix_counters)
-send_counters = false
+#legacyNamespace = false
+#prefix_rates = "stats.counters."
+#prefix_counters = "stats.counters."
+#prefix_timers = "stats.timers."
+#prefix_gauges = "stats.gauges."
+
+# send rates for counters (using prefix_rates)
 
 percentile_thresholds = "90,75"
 max_timers_per_s = 1000

--- a/statsdaemon.ini
+++ b/statsdaemon.ini
@@ -14,8 +14,15 @@ instance = "${HOST}"
 
 # prefixes for the various types.  they should probably end with a dot.
 prefix_rates = "stats."
+prefix_counters = "stats.counters."
 prefix_timers = "stats.timers."
 prefix_gauges = "stats.gauges."
+
+# send rates for counters (using prefix_rates)
+send_rates = true
+
+# send count for counters (using prefix_counters)
+send_counters = false
 
 percentile_thresholds = "90,75"
 max_timers_per_s = 1000

--- a/statsdaemon.ini
+++ b/statsdaemon.ini
@@ -14,23 +14,26 @@ instance = "${HOST}"
 
 # prefixes for the various types.  they should probably end with a dot.
 # Defaults are in line with etsy statsd using legacy namespacing (not recommended)
-legacyNamespace = true
+legacy_namespace = true
 prefix_rates = "stats."
 prefix_counters = "stats_counts."
 prefix_timers = "stats.timers."
 prefix_gauges = "stats.gauges."
 
-# Recommended (legacyNamespace = false)
+# Recommended (legacy_namespace = false)
 # counts -> stats.counters.$metric.count
 # rates -> stats.counters.$metric.rate
 
-#legacyNamespace = false
+#legacy_namespace = false
 #prefix_rates = "stats.counters."
 #prefix_counters = "stats.counters."
 #prefix_timers = "stats.timers."
 #prefix_gauges = "stats.gauges."
 
 # send rates for counters (using prefix_rates)
+flush_rates = true
+# send count for counters (using prefix_counters)
+flush_counts = false
 
 percentile_thresholds = "90,75"
 max_timers_per_s = 1000

--- a/statsdaemon/main.go
+++ b/statsdaemon/main.go
@@ -41,7 +41,9 @@ var (
 	prefix_timers   = config.String("prefix_timers", "stats.timers.")
 	prefix_gauges   = config.String("prefix_gauges", "stats.gauges.")
 
-	legacyNamespace = config.Bool("legacyNamespace", true)
+	legacy_namespace = config.Bool("legacy_namespace", true)
+	flush_rates      = config.Bool("flush_rates", true)
+	flush_counts     = config.Bool("flush_counts", false)
 
 	percentile_thresholds = config.String("percentile_thresholds", "")
 	max_timers_per_s      = config.Uint64("max_timers_per_s", 1000)
@@ -113,7 +115,7 @@ func main() {
 		}()
 	}
 
-	daemon := statsdaemon.New(inst, *prefix_rates, *prefix_timers, *prefix_gauges, *prefix_counters, *pct, *flushInterval, MAX_UNPROCESSED_PACKETS, *max_timers_per_s, signalchan, *debug, *legacyNamespace)
+	daemon := statsdaemon.New(inst, *prefix_rates, *prefix_timers, *prefix_gauges, *prefix_counters, *pct, *flushInterval, MAX_UNPROCESSED_PACKETS, *max_timers_per_s, signalchan, *debug, *legacy_namespace, *flush_rates, *flush_counts)
 	if *debug {
 		consumer := make(chan interface{}, 100)
 		daemon.Invalid_lines.Register(consumer)
@@ -124,5 +126,4 @@ func main() {
 		}()
 	}
 	daemon.Run(*listen_addr, *admin_addr, *graphite_addr)
-
 }

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -125,42 +125,42 @@ func TestMean(t *testing.T) {
 	assert.Equal(t, matched, true)
 }
 
-func TestCountersLegacyNamespaceFalse(t *testing.T) {
+func getGraphiteSendForCounter(cnt *counters.Counters, input string) (string, int64) {
 	// Some data with expected sum of 6
-	d := []byte("logins:1|c\nlogins:2|c\nlogins:3|c")
+	d := []byte(input)
 	packets := udp.ParseMessage(d, prefix_internal, output, udp.ParseLine)
 
-	counters := counters.New("rates.", "counters.", false)
-
 	for _, p := range packets {
-		counters.Add(p)
+		cnt.Add(p)
 	}
 
 	var buff bytes.Buffer
-	num := counters.Process(&buff, 1, 10)
-	assert.Equal(t, num, int64(2))
-	dataForGraphite := buff.String()
+	num := cnt.Process(&buff, 1, 10)
+	return buff.String(), num
+}
 
+func TestCountersLegacyNamespaceFalse(t *testing.T) {
+	cnt := counters.New("rates.", "counters.", false, true, true)
+	dataForGraphite, num := getGraphiteSendForCounter(cnt, "logins:1|c\nlogins:2|c\nlogins:3|c")
+
+	assert.Equal(t, num, int64(2))
 	assert.Equal(t, "counters.logins.count 6.000000 1\nrates.logins.rate 0.600000 1\n", dataForGraphite)
 }
 
 func TestCountersLegacyNamespaceTrue(t *testing.T) {
-	// Some data with expected sum of 6
-	d := []byte("logins:1|c\nlogins:2|c\nlogins:3|c")
-	packets := udp.ParseMessage(d, prefix_internal, output, udp.ParseLine)
+	cnt := counters.New("rates.", "counters.", true, true, true)
+	dataForGraphite, num := getGraphiteSendForCounter(cnt, "logins:1|c\nlogins:2|c\nlogins:3|c")
 
-	counters := counters.New("rates.", "counters.", true)
-
-	for _, p := range packets {
-		counters.Add(p)
-	}
-
-	var buff bytes.Buffer
-	num := counters.Process(&buff, 1, 10)
 	assert.Equal(t, num, int64(2))
-	dataForGraphite := buff.String()
-
 	assert.Equal(t, "counters.logins 6.000000 1\nrates.logins 0.600000 1\n", dataForGraphite)
+}
+
+func TestCountersLegacyNamespaceTrueFlushCountsFalse(t *testing.T) {
+	cnt := counters.New("rates.", "counters.", true, true, false)
+	dataForGraphite, num := getGraphiteSendForCounter(cnt, "logins:1|c\nlogins:2|c\nlogins:3|c")
+
+	assert.Equal(t, num, int64(1))
+	assert.Equal(t, "rates.logins 0.600000 1\n", dataForGraphite)
 }
 
 func TestUpperPercentile(t *testing.T) {
@@ -217,7 +217,7 @@ func TestMetrics20Count(t *testing.T) {
 	d := []byte("foo=bar.target_type=count.unit=B:5|c\nfoo=bar.target_type=count.unit=B:10|c")
 	packets := udp.ParseMessage(d, prefix_internal, output, udp.ParseLine)
 
-	c := counters.New("", "", true)
+	c := counters.New("", "", true, true, false)
 	for _, p := range packets {
 		c.Add(p)
 	}
@@ -261,7 +261,7 @@ func TestLowerPercentile(t *testing.T) {
 func BenchmarkMillionDifferentCountersAddAndProcess(b *testing.B) {
 	metrics := getDifferentCounters(1000000)
 	b.ResetTimer()
-	c := counters.New("bar", "", true)
+	c := counters.New("bar", "", true, true, false)
 	for i := 0; i < len(metrics); i++ {
 		for n := 0; n < b.N; n++ {
 			c.Add(&metrics[i])
@@ -333,7 +333,7 @@ func BenchmarkMillionSameTimersAddAndProcess(b *testing.B) {
 }
 
 func BenchmarkIncomingMetrics(b *testing.B) {
-	daemon := New("test", "rates.", "timers.", "gauges.", "counters.", timers.Percentiles{}, 10, 1000, 1000, nil, false, true)
+	daemon := New("test", "rates.", "timers.", "gauges.", "counters.", timers.Percentiles{}, 10, 1000, 1000, nil, false, true, true, false)
 	daemon.Clock = clock.NewMock()
 	total := float64(0)
 	totalLock := sync.Mutex{}
@@ -378,7 +378,7 @@ func BenchmarkIncomingMetrics(b *testing.B) {
 }
 
 func BenchmarkIncomingMetricAmounts(b *testing.B) {
-	daemon := New("test", "rates.", "timers.", "gauges.", "counters.", timers.Percentiles{}, 10, 1000, 1000, nil, false, true)
+	daemon := New("test", "rates.", "timers.", "gauges.", "counters.", timers.Percentiles{}, 10, 1000, 1000, nil, false, true, true, false)
 	daemon.Clock = clock.NewMock()
 	daemon.submitFunc = func(c *counters.Counters, g *gauges.Gauges, t *timers.Timers, deadline time.Time) error {
 		return nil

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -3,6 +3,12 @@ package statsdaemon
 import (
 	"bytes"
 	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/bmizerany/assert"
 	"github.com/vimeo/statsdaemon/common"
@@ -10,11 +16,6 @@ import (
 	"github.com/vimeo/statsdaemon/gauges"
 	"github.com/vimeo/statsdaemon/timers"
 	"github.com/vimeo/statsdaemon/udp"
-	"regexp"
-	"strings"
-	"sync"
-	"testing"
-	"time"
 )
 
 var output = common.NullOutput()
@@ -178,7 +179,7 @@ func TestMetrics20Count(t *testing.T) {
 	d := []byte("foo=bar.target_type=count.unit=B:5|c\nfoo=bar.target_type=count.unit=B:10|c")
 	packets := udp.ParseMessage(d, prefix_internal, output, udp.ParseLine)
 
-	c := counters.New("")
+	c := counters.New(true, "", false, "")
 	for _, p := range packets {
 		c.Add(p)
 	}
@@ -222,7 +223,7 @@ func TestLowerPercentile(t *testing.T) {
 func BenchmarkMillionDifferentCountersAddAndProcess(b *testing.B) {
 	metrics := getDifferentCounters(1000000)
 	b.ResetTimer()
-	c := counters.New("bar")
+	c := counters.New(true, "bar", false, "")
 	for i := 0; i < len(metrics); i++ {
 		for n := 0; n < b.N; n++ {
 			c.Add(&metrics[i])


### PR DESCRIPTION
This PR adds support for regular statsd counters that are aggregated and sent to graphite using a `.count`  suffix . 

Why?
Currently vimeo/statsdaemon only sends rates for counters to a rates prefix. Missing the standard `.count` (sum for flush interval) metric. The count metric is very important for many types of metrics where accurate aggregation across rollup ranges is important. For example using summarize to group in to 1 hour buckets or 1 day buckets, using rates this is not possible (unless you apply a scale factor, but that will only work for one rollup region). Also rates will be aggregated in graphite using averages which is not very good if you care about accurate totals. 

In many ways the `.count` metric is more useful as the rate can always reliably be calculated from it using graphite's scaleToSeconds function. 

Implementation:
In order not to change things for current users of vimeo/statsdaemon new options have been added. 

- send_rates   (default: **true**)
- send_counters   (default: **false**)
- prefix_counters   (default: **stats.counters.**)

Example: 
So if send_counters set to true and prefix_counters set to "stats.counters."

StatD Input
`logins:1|c\nlogins:2|c\nlogins:3|c`

Will send to graphite
`stats.counters.logins.count 6.000000 <epoch>`

If rate is also enabled (if flush interval is 10s):
`stats.rates.logins 0.600000 <epoch>`

Open to any suggested changes to this PR. 
